### PR TITLE
add note about running in terminal, not iTerm

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,5 @@ https://user-images.githubusercontent.com/279531/208549243-56047321-4ed1-47d6-bd
 * Run by typing `python main.py`. 
 * By default, will run using semantic embeddings. If you want to try the highly experimental finetuned model, run `python main.py llm`.
 * Right now this will only work on MacOS as it uses on-device speech recognition (using the `hear` library/app).
+* It much be launched within Terminal, not iTerm, for `hear` to appropriately request Speech Recognition and Microphone permissions. See https://github.com/sveinbjornt/hear/issues/15
 * It would be trivial to add whisper, feel free to do so and send me a pull request.
-
-


### PR DESCRIPTION
... to avoid https://github.com/sveinbjornt/hear/issues/15

When running in iTerm, `hear` gives `Abort trap: 6`, but that doesn't get trapped, so the resulting error is an attempted fork loop:
```
Starting ./hear
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
	- Avoid using `tokenizers` before the fork if possible
	- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
Starting ./hear
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
	- Avoid using `tokenizers` before the fork if possible
	- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
Starting ./hear
```
etc.